### PR TITLE
BugFix 1201774

### DIFF
--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -72,7 +72,7 @@
           }
         }
         if ((data.status === 'failed' || data.status === 'finished with error' || data.status === 'finished') && $scope.configPlaybookTaskID === data.task_id) {
-          getPlaybookResult();
+          _getPlaybookResult();
         }
       }).then(function (data) {
         subscription = data;
@@ -86,11 +86,23 @@
       }
     });
 
-    function getPlaybookResult() {
+    function _getPlaybookResult() {
       var endpoint = API.WORKFLOW + 'api/workflows/' + $scope.parent_wf_id + '/';
       $http.get(endpoint).then(function (response) {
-        if (response.data.status === 'finished' || response.data.status === 'finished with error') {
+        if (response.data.status === 'finished') {
+          if (subscription) {
+            websocketService.unsubscribe(subscription);
+          }
           WizardHandler.wizard('solutionpackWizard').next();
+        }
+        else if (response.data.status === 'finished with error' || response.data.status === 'failed') {
+          if (!$scope.isToaster) {
+            toaster.warning({
+              body: "The \"Setup CICD Environment\" playbook has failed. Check the playbook logs for details."
+            });
+            $scope.isToaster = true;
+            websocketService.unsubscribe(subscription);
+          }
         }
         $scope.isPlaybookExecuted = false;
       });
@@ -235,7 +247,6 @@
     }
 
     function moveVersionControlNext() {
-      initWebsocket();
       triggerPlaybook();
     }
 
@@ -284,6 +295,8 @@
     }
 
     function triggerPlaybook() {
+      $scope.isToaster = false;
+      initWebsocket();
       var queryPayload =
       {
         "request": $scope.configuredEnv


### PR DESCRIPTION
#### PMDB: https://pmdb.fortinet.com/ProjectManagement/project/detail/38683

#### Mantis:
1201774 | Error handling in `Setup CICD Environment` playbook
   - `RCA`:  An error toaster message should be displayed if the "Setup CICD Environment" playbook fails.
   - `Solution`: Added error handling in if the "Setup CICD Environment" playbook fails.

#### Test Case:
- Error message will display if the "Setup CICD Environment" playbook failed and Wizard will not take user to "Finish" Page
<img width="1912" height="962" alt="image" src="https://github.com/user-attachments/assets/d18c6062-6cf4-468c-aaf9-ef89e0fcd71f" />

- If the "Setup CICD Environment" playbook executed successfully then Wizard will take user to "Finish" Page

